### PR TITLE
Channels now fade according to NPU configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,8 @@ The following modules/controls have been verified to work correctly with this in
 - Network Processor Module (DIN-NPU-00-01-PLUS) **REQUIRED**
 - 8 Channel Dimmer Module (DIN-02-08-PLUS)
 - Evo Contact Input Module (EVO-INT_CI_xx)
-- 10 Button Geneva Control Plate (GVA-SGP-55) :warning: **PARTIAL SUPPORT**
+- Input-Output module (DIN-INT-00-08-PLUS) :warning: *Beta support - unverified*
+- 10 Button Geneva Control Plate (GVA-SGP-55) :warning: *Partial support - still some issues*
 
 ## eDIN+
 More information about the eDIN+ system can be found on Mode Lighting's website: http://www.modelighting.com/products/edin-plus/

--- a/README.md
+++ b/README.md
@@ -2,7 +2,9 @@
 
 [![hacs_badge](https://img.shields.io/badge/HACS-Custom-41BDF5.svg)](https://github.com/hacs/integration)
 
-Tested on HA 2022.12.6 - 2023.7 and eDIN+ firmware SW00120.2.4.1.44. Please note eDIN+ firmware SW00.120.2.3.x.x is NOT currently supported.
+Tested on HA 2022.12.6 - 2023.7 and eDIN+ firmware SW00120.2.4.1.44. 
+
+Please note eDIN+ firmware SW00.120.2.3.x.x is **NOT** currently supported.
 
 The state of this component is: Local Push
 

--- a/custom_components/edinplus/__init__.py
+++ b/custom_components/edinplus/__init__.py
@@ -7,7 +7,7 @@ import logging
 # Import constants
 from .const import DOMAIN
 
-LOGGER = logging.getLogger(DOMAIN)
+LOGGER = logging.getLogger(__name__)
 
 from . import edinplus
 

--- a/custom_components/edinplus/__init__.py
+++ b/custom_components/edinplus/__init__.py
@@ -4,7 +4,10 @@ from __future__ import annotations
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 import logging
-LOGGER = logging.getLogger("edinplus")
+# Import constants
+from .const import DOMAIN
+
+LOGGER = logging.getLogger(DOMAIN)
 
 from . import edinplus
 
@@ -16,7 +19,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Set up NPU from config entry."""
     # This stores an instance of the NPU class that communicates with other devices
     hub = edinplus.edinplus_NPU_instance(hass, entry.data["host"], entry.entry_id)
-    hass.data.setdefault("edinplus", {})[entry.entry_id] = hub
+    hass.data.setdefault(DOMAIN, {})[entry.entry_id] = hub
     
     LOGGER.debug("Initialised NPU instance")
 
@@ -48,6 +51,6 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     # This has just been left as in the example repo - to be further investigated/improved
     unload_ok = await hass.config_entries.async_unload_platforms(entry, PLATFORMS)
     if unload_ok:
-        hass.data["edinplus"].pop(entry.entry_id)
+        hass.data[DOMAIN].pop(entry.entry_id)
 
     return unload_ok

--- a/custom_components/edinplus/config_flow.py
+++ b/custom_components/edinplus/config_flow.py
@@ -14,7 +14,7 @@ from .edinplus import edinplus_NPU_instance
 # Import constants
 from .const import DOMAIN
 
-_LOGGER = logging.getLogger(__name__) # Should replace __name__ with DOMAIN imported from constants
+_LOGGER = logging.getLogger(DOMAIN)
 
 # This is the schema that used to display the UI to the user.
 # At the moment user is just asked for the NPU address.
@@ -61,7 +61,7 @@ async def validate_input(hass: HomeAssistant, data: dict) -> dict[str, Any]:
     return {"title": data["host"]}
 
 
-class ConfigFlow(config_entries.ConfigFlow, domain="edinplus"):
+class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
     """Handle a config flow for eDIN+."""
 
     VERSION = 1

--- a/custom_components/edinplus/config_flow.py
+++ b/custom_components/edinplus/config_flow.py
@@ -14,7 +14,7 @@ from .edinplus import edinplus_NPU_instance
 # Import constants
 from .const import DOMAIN
 
-_LOGGER = logging.getLogger(DOMAIN)
+_LOGGER = logging.getLogger(__name__)
 
 # This is the schema that used to display the UI to the user.
 # At the moment user is just asked for the NPU address.

--- a/custom_components/edinplus/device_trigger.py
+++ b/custom_components/edinplus/device_trigger.py
@@ -34,7 +34,7 @@ TRIGGER_TYPES = NEWSTATE_TO_BUTTONEVENT.values()
 
 # Limit the devices that can have input events to the button plates (2) and EVO contact input module (9). 
 # This should probably be extended to 15 (the eDIN I/O module) once able to verify functionality with hardware
-INPUT_MODELS = {DEVCODE_TO_PRODNAME[2],DEVCODE_TO_PRODNAME[9]}
+INPUT_MODELS = {DEVCODE_TO_PRODNAME[2],DEVCODE_TO_PRODNAME[9],DEVCODE_TO_PRODNAME[15]}
 
 LOGGER = logging.getLogger(__name__) # Should replace __name__ with DOMAIN imported from const.py for consistency 
 

--- a/custom_components/edinplus/device_trigger.py
+++ b/custom_components/edinplus/device_trigger.py
@@ -36,7 +36,7 @@ TRIGGER_TYPES = NEWSTATE_TO_BUTTONEVENT.values()
 # This should probably be extended to 15 (the eDIN I/O module) once able to verify functionality with hardware
 INPUT_MODELS = {DEVCODE_TO_PRODNAME[2],DEVCODE_TO_PRODNAME[9],DEVCODE_TO_PRODNAME[15]}
 
-LOGGER = logging.getLogger(__name__) # Should replace __name__ with DOMAIN imported from const.py for consistency 
+LOGGER = logging.getLogger(DOMAIN)
 
 # Set the trigger types to the different types of button event (imported from const.py)
 TRIGGER_SCHEMA = DEVICE_TRIGGER_BASE_SCHEMA.extend(

--- a/custom_components/edinplus/device_trigger.py
+++ b/custom_components/edinplus/device_trigger.py
@@ -36,7 +36,7 @@ TRIGGER_TYPES = NEWSTATE_TO_BUTTONEVENT.values()
 # This should probably be extended to 15 (the eDIN I/O module) once able to verify functionality with hardware
 INPUT_MODELS = {DEVCODE_TO_PRODNAME[2],DEVCODE_TO_PRODNAME[9],DEVCODE_TO_PRODNAME[15]}
 
-LOGGER = logging.getLogger(DOMAIN)
+LOGGER = logging.getLogger(__name__)
 
 # Set the trigger types to the different types of button event (imported from const.py)
 TRIGGER_SCHEMA = DEVICE_TRIGGER_BASE_SCHEMA.extend(

--- a/custom_components/edinplus/edinplus.py
+++ b/custom_components/edinplus/edinplus.py
@@ -27,7 +27,7 @@ from homeassistant.const import (
 # Import constants
 from .const import *
 
-LOGGER = logging.getLogger(__name__) # This should use DOMAIN, rather than __name__
+LOGGER = logging.getLogger(DOMAIN)
 
 # Interact with NPU using the TCP stream (the writer object should be stored in the NPU class)
 async def tcp_send_message(writer,message):

--- a/custom_components/edinplus/edinplus.py
+++ b/custom_components/edinplus/edinplus.py
@@ -27,7 +27,7 @@ from homeassistant.const import (
 # Import constants
 from .const import *
 
-LOGGER = logging.getLogger(DOMAIN)
+LOGGER = logging.getLogger(__name__)
 
 # Interact with NPU using the TCP stream (the writer object should be stored in the NPU class)
 async def tcp_send_message(writer,message):

--- a/custom_components/edinplus/light.py
+++ b/custom_components/edinplus/light.py
@@ -23,7 +23,7 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.typing import ConfigType, DiscoveryInfoType
 
-_LOGGER = logging.getLogger(__name__) # Should use DOMAIN imported from const
+LOGGER = logging.getLogger(__name__)
 
 # This function is called as part of the __init__.async_setup_entry (via the
 # hass.config_entries.async_forward_entry_setup call)
@@ -47,7 +47,7 @@ class EdinPlusLightChannel(LightEntity):
 
     def __init__(self, light) -> None:
         """Initialize an eDIN+ Light Channel."""
-        _LOGGER.info(pformat(light))
+        # LOGGER.info(pformat(light))
         self._light = light
         self._attr_name = self._light.name
         self._attr_unique_id = f"{self._light.light_id}_light"
@@ -126,7 +126,7 @@ class EdinPlusLightChannel(LightEntity):
         This is the only method that should fetch new data for Home Assistant.
         """
         # This should no longer be used, as this relies on HTTP rather than the TCP stream
-        _LOGGER.warning("async HTTP update performed - this action should be updated to use the TCP stream")
+        LOGGER.warning("async HTTP update performed - this action should be updated to use the TCP stream")
         self._brightness = await self._light.get_brightness()
         if int(self._brightness) > 0:
             self._state = True

--- a/custom_components/edinplus/light.py
+++ b/custom_components/edinplus/light.py
@@ -23,7 +23,7 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.typing import ConfigType, DiscoveryInfoType
 
-_LOGGER = logging.getLogger("edinplus") # Should use DOMAIN imported from const
+_LOGGER = logging.getLogger(DOMAIN) # Should use DOMAIN imported from const
 
 # This function is called as part of the __init__.async_setup_entry (via the
 # hass.config_entries.async_forward_entry_setup call)
@@ -35,7 +35,7 @@ async def async_setup_entry(
     """Add cover for passed config_entry in HA."""
     # The hub is loaded from the associated hass.data entry that was created in the
     # __init__.async_setup_entry function
-    npu = hass.data["edinplus"][config_entry.entry_id]
+    npu = hass.data[DOMAIN][config_entry.entry_id]
 
     # Add all entities to HA
     async_add_entities(EdinPlusLightChannel(light) for light in npu.lights)
@@ -73,7 +73,7 @@ class EdinPlusLightChannel(LightEntity):
     def device_info(self) -> DeviceInfo:
         """Return the device info"""
         return DeviceInfo(
-            identifiers={("edinplus",self._light.light_id)},
+            identifiers={(DOMAIN,self._light.light_id)},
                 name=self.name,
                 sw_version="1.0.0",
                 model=self._light.model,

--- a/custom_components/edinplus/light.py
+++ b/custom_components/edinplus/light.py
@@ -23,7 +23,7 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.typing import ConfigType, DiscoveryInfoType
 
-_LOGGER = logging.getLogger(DOMAIN) # Should use DOMAIN imported from const
+_LOGGER = logging.getLogger(__name__) # Should use DOMAIN imported from const
 
 # This function is called as part of the __init__.async_setup_entry (via the
 # hass.config_entries.async_forward_entry_setup call)

--- a/custom_components/edinplus/manifest.json
+++ b/custom_components/edinplus/manifest.json
@@ -8,5 +8,5 @@
     "iot_class": "local_push",
     "issue_tracker": "https://github.com/sftgunner/edinplus-integration/issues",
     "requirements": [],
-    "version": "0.5.5"
+    "version": "0.5.6"
 }


### PR DESCRIPTION
- If a channel has an appropriate scene proxy, it will now fade on/off with that scene's fadetime (in accordance with feedback from #9)
- Debug logs now actually give useful messages!
- Initial support for the I/O module has been added in beta - please note that I don't have access to this hardware, so am just assuming it functions similarly to the EVO Contact Input module!
- There are some stability issues that have been observed in development when the integration is frequently reloaded - please try and avoid this if possible! So far a reboot of HomeAssistant seems to fix these when they occur.